### PR TITLE
fix wrong libz download dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ set(libz_src
 
 add_custom_command(
   OUTPUT ${libz_src}
-  DEPENDS ${libz_download}
+  DEPENDS libz_download
 )
 
 include_directories(


### PR DESCRIPTION
libz_download isnt a variable, using it as a variable name is empty so the download dependency isnt made